### PR TITLE
Update urls.py

### DIFF
--- a/Part-03 User Payment and Order Management/Final/account/urls.py
+++ b/Part-03 User Payment and Order Management/Final/account/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
                                                 form_class=UserLoginForm), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='/account/login/'), name='logout'),
     path('register/', views.account_register, name='register'),
-    path('activate/<slug:uidb64>/<slug:token>)/', views.account_activate, name='activate'),
+    path('activate/<slug:uidb64>/<slug:token>/', views.account_activate, name='activate'),
     # Reset password
     path('password_reset/', auth_views.PasswordResetView.as_view(template_name="account/user/password_reset_form.html",
                                                                  success_url='password_reset_email_confirm',


### PR DESCRIPTION
Issue:
URL Path for activate containing an extra ")" due to which redirect not working for dashboard.

Fix:
Removed ")" from URL path for account_activate